### PR TITLE
Set brush range to last 30 days

### DIFF
--- a/src/components/charts/dailyCase.js
+++ b/src/components/charts/dailyCase.js
@@ -16,7 +16,6 @@ import {
     Tooltip,
     Legend,
     Brush,
-    ResponsiveContainer
 } from "recharts";
 import Loading from "../loading";
 
@@ -173,10 +172,11 @@ function Chart({data, quantity}) {
                 >
                     <CartesianGrid strokeDasharray="3 3"/>
                     <Brush
-                        travellerWidth={30}
+                        travellerWidth={chartWidth() < 1000 ? 30 : 15}
                         width={chartWidth() * 0.8}
                         dataKey="tanggal"
                         x={chartWidth() * 0.1}
+                        startIndex={data ? data.length - 30 : 0}
                     />
                     <XAxis dataKey="tanggal"/>
                     <YAxis/>


### PR DESCRIPTION
- Range can be changed by resizing the brush with traveller width
- Traveller width depends on window size. if <1000 px assume mobile and use larger traveller to compensate touch screen
- also removed unused import